### PR TITLE
Update HTTP.hs

### DIFF
--- a/src/Database/CouchDB/HTTP.hs
+++ b/src/Database/CouchDB/HTTP.hs
@@ -91,7 +91,6 @@ reopenConnection = CouchMonad $ \conn -> do
 
 makeHeaders bodyLen =
   [ Header HdrContentType "application/json"
-  , Header HdrContentEncoding "UTF-8"
   , Header HdrConnection "keep-alive"
   , Header HdrContentLength (show bodyLen)
   ]


### PR DESCRIPTION
Remove the fault line (see https://github.com/arjunguha/haskell-couchdb/issues/17, basically Content-Encoding: "utf-8" is incorrect header)
