### PR TITLE
raise upper bound for base to <4.15 to support building with ghc-8.10

### DIFF
--- a/CouchDB.cabal
+++ b/CouchDB.cabal
@@ -42,7 +42,7 @@ Test-Suite test-couchdb
 Library
   Hs-Source-Dirs: src
   Build-Depends:
-    base >= 4 && < 4.14, mtl, containers, network, network-uri, HTTP>=4000.0.4, json>=0.4.3, utf8-string >= 0.3.6 && <= 1.1, bytestring
+    base >= 4 && < 4.15, mtl, containers, network, network-uri, HTTP>=4000.0.4, json>=0.4.3, utf8-string >= 0.3.6 && <= 1.1, bytestring
   if flag(network-uri)
     build-depends: network >= 2.6, network-uri >= 2.6
   else


### PR DESCRIPTION
I found it builds just fine with ghc-8.10, too. BTW when I run the tests I get errors. Perhaps that is because I haven't installed couchdb on my machine?